### PR TITLE
검색 화면 리팩토링 & 페이지네이션

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Alamofire (5.0.0)
+  - Alamofire (5.0.2)
   - AssistantKit (0.6.1)
   - Crashlytics (3.9.3):
     - Fabric (~> 1.7.2)
@@ -174,7 +174,7 @@ SPEC REPOS:
     - SWXMLHash
 
 SPEC CHECKSUMS:
-  Alamofire: 58ff2bfb8daaacaa233d5c36e37b10a5248f59b1
+  Alamofire: 3ba7a4db18b4f62c4a1c0e1cb39d7f3d52e10ada
   AssistantKit: 7dd40c019e9a06e93555ed58498a2d212fcb408d
   Crashlytics: dbb07d01876c171c5ccbdf7826410380189e452c
   Fabric: 25d0963b691fc97be566392243ff0ecef5a68338

--- a/groov.xcodeproj/project.pbxproj
+++ b/groov.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		31251DBFEDF78548A1A2A767 /* Pods_groov.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ABDD6A5EDEFF369926A285F5 /* Pods_groov.framework */; };
 		C6172ECD2400380B00F2B5C1 /* LoadingIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6172ECC2400380B00F2B5C1 /* LoadingIndicatorView.swift */; };
 		C6172ECF240044A900F2B5C1 /* Debouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6172ECE240044A900F2B5C1 /* Debouncer.swift */; };
+		C6172ED224040D3300F2B5C1 /* SearchViewDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6172ED124040D3300F2B5C1 /* SearchViewDataManager.swift */; };
 		C61B73DB1E9C69D4003AE091 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C61B73DA1E9C69D4003AE091 /* Assets.xcassets */; };
 		C61C0BC81D38C2C90067D389 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C61C0BC71D38C2C90067D389 /* Constants.swift */; };
 		C61D9B4223FD6DC100B4E0AD /* KeyboardNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = C61D9B4123FD6DC100B4E0AD /* KeyboardNotification.swift */; };
@@ -107,6 +108,7 @@
 		ABDD6A5EDEFF369926A285F5 /* Pods_groov.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_groov.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C6172ECC2400380B00F2B5C1 /* LoadingIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingIndicatorView.swift; sourceTree = "<group>"; };
 		C6172ECE240044A900F2B5C1 /* Debouncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debouncer.swift; sourceTree = "<group>"; };
+		C6172ED124040D3300F2B5C1 /* SearchViewDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewDataManager.swift; sourceTree = "<group>"; };
 		C61B73DA1E9C69D4003AE091 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C61C0BC71D38C2C90067D389 /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		C61D9B4123FD6DC100B4E0AD /* KeyboardNotification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardNotification.swift; sourceTree = "<group>"; };
@@ -266,6 +268,7 @@
 			children = (
 				C64FCE2E23FED70200790DA5 /* YoutubeAPI.swift */,
 				C64FCE2C23FED1BE00790DA5 /* SearchAPIHandler.swift */,
+				C6172ED124040D3300F2B5C1 /* SearchViewDataManager.swift */,
 			);
 			path = SearchHelper;
 			sourceTree = "<group>";
@@ -574,6 +577,7 @@
 				C64FCE2F23FED70200790DA5 /* YoutubeAPI.swift in Sources */,
 				1F37621520600076001ED5BB /* PlaylistListViewController.swift in Sources */,
 				1F2783BC205EA8C00001DFEB /* BaseViewController.swift in Sources */,
+				C6172ED224040D3300F2B5C1 /* SearchViewDataManager.swift in Sources */,
 				1F376201205FFFBC001ED5BB /* Video.swift in Sources */,
 				1F37621320600075001ED5BB /* GRAlertViewController.swift in Sources */,
 				1F37621220600075001ED5BB /* LibraryViewController.swift in Sources */,

--- a/groov.xcodeproj/project.pbxproj
+++ b/groov.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		1F376225206000D1001ED5BB /* SearchVideoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F37621E206000D1001ED5BB /* SearchVideoTableViewCell.swift */; };
 		1FAE89861FAA551000CF900D /* license.html in Resources */ = {isa = PBXBuildFile; fileRef = 1FAE89841FAA551000CF900D /* license.html */; };
 		31251DBFEDF78548A1A2A767 /* Pods_groov.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ABDD6A5EDEFF369926A285F5 /* Pods_groov.framework */; };
+		C6172ECD2400380B00F2B5C1 /* LoadingIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6172ECC2400380B00F2B5C1 /* LoadingIndicatorView.swift */; };
+		C6172ECF240044A900F2B5C1 /* Debouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6172ECE240044A900F2B5C1 /* Debouncer.swift */; };
 		C61B73DB1E9C69D4003AE091 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C61B73DA1E9C69D4003AE091 /* Assets.xcassets */; };
 		C61C0BC81D38C2C90067D389 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C61C0BC71D38C2C90067D389 /* Constants.swift */; };
 		C61D9B4223FD6DC100B4E0AD /* KeyboardNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = C61D9B4123FD6DC100B4E0AD /* KeyboardNotification.swift */; };
@@ -103,6 +105,8 @@
 		97596A9D467582EEF5030BE1 /* Pods-groov.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-groov.release.xcconfig"; path = "Pods/Target Support Files/Pods-groov/Pods-groov.release.xcconfig"; sourceTree = "<group>"; };
 		A82A0158A517718A8183ABD2 /* Pods_groovTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_groovTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABDD6A5EDEFF369926A285F5 /* Pods_groov.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_groov.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C6172ECC2400380B00F2B5C1 /* LoadingIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingIndicatorView.swift; sourceTree = "<group>"; };
+		C6172ECE240044A900F2B5C1 /* Debouncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debouncer.swift; sourceTree = "<group>"; };
 		C61B73DA1E9C69D4003AE091 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C61C0BC71D38C2C90067D389 /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		C61D9B4123FD6DC100B4E0AD /* KeyboardNotification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardNotification.swift; sourceTree = "<group>"; };
@@ -204,6 +208,7 @@
 				C61C0BC71D38C2C90067D389 /* Constants.swift */,
 				1F0D31AE207936D000F50FE0 /* TrackUtil.swift */,
 				C61D9B4123FD6DC100B4E0AD /* KeyboardNotification.swift */,
+				C6172ECE240044A900F2B5C1 /* Debouncer.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -231,6 +236,7 @@
 				1F37621C206000D1001ED5BB /* SearchSuggestTableViewCell.swift */,
 				1F37621D206000D1001ED5BB /* GRSearchBar.swift */,
 				1F37621E206000D1001ED5BB /* SearchVideoTableViewCell.swift */,
+				C6172ECC2400380B00F2B5C1 /* LoadingIndicatorView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -557,6 +563,7 @@
 				1F37621F206000D1001ED5BB /* GRSearchController.swift in Sources */,
 				C61C0BC81D38C2C90067D389 /* Constants.swift in Sources */,
 				C61D9B4223FD6DC100B4E0AD /* KeyboardNotification.swift in Sources */,
+				C6172ECD2400380B00F2B5C1 /* LoadingIndicatorView.swift in Sources */,
 				1F376223206000D1001ED5BB /* SearchSuggestTableViewCell.swift in Sources */,
 				1F37621620600076001ED5BB /* SettingsViewController.swift in Sources */,
 				1F376222206000D1001ED5BB /* MenuTableViewCell.swift in Sources */,
@@ -573,6 +580,7 @@
 				C64FCE2D23FED1BE00790DA5 /* SearchAPIHandler.swift in Sources */,
 				1F376221206000D1001ED5BB /* VideoListTableViewCell.swift in Sources */,
 				1F21B9431D2D61A2001F1722 /* Extensions.swift in Sources */,
+				C6172ECF240044A900F2B5C1 /* Debouncer.swift in Sources */,
 				1F0D31AF207936D000F50FE0 /* TrackUtil.swift in Sources */,
 				1F376208205FFFD0001ED5BB /* YTPlayerView.m in Sources */,
 			);

--- a/groov/Base.lproj/Main.storyboard
+++ b/groov/Base.lproj/Main.storyboard
@@ -1133,10 +1133,15 @@
                                     <outlet property="delegate" destination="Aqn-tB-DsG" id="7le-8o-geE"/>
                                 </connections>
                             </tableView>
+                            <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="2y7-Wz-NeB">
+                                <rect key="frame" x="177.5" y="301.5" width="20" height="20"/>
+                            </activityIndicatorView>
                         </subviews>
                         <color key="backgroundColor" red="0.11764705882352941" green="0.12941176470588234" blue="0.14117647058823529" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
+                            <constraint firstItem="2y7-Wz-NeB" firstAttribute="centerX" secondItem="Nvp-PC-wLH" secondAttribute="centerX" id="HAE-Zc-msT"/>
                             <constraint firstItem="Nvp-PC-wLH" firstAttribute="centerX" secondItem="bsA-rN-W2z" secondAttribute="centerX" id="Wfa-1F-9KQ"/>
+                            <constraint firstItem="2y7-Wz-NeB" firstAttribute="centerY" secondItem="Nvp-PC-wLH" secondAttribute="centerY" id="igz-od-aE6"/>
                             <constraint firstItem="Nvp-PC-wLH" firstAttribute="height" secondItem="bsA-rN-W2z" secondAttribute="height" id="k6X-ld-8gM"/>
                             <constraint firstItem="Nvp-PC-wLH" firstAttribute="width" secondItem="bsA-rN-W2z" secondAttribute="width" id="qPm-eM-h73"/>
                             <constraint firstItem="Nvp-PC-wLH" firstAttribute="centerY" secondItem="bsA-rN-W2z" secondAttribute="centerY" id="uNB-PM-u2e"/>
@@ -1144,6 +1149,7 @@
                     </view>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
                     <connections>
+                        <outlet property="activityIndicatorView" destination="2y7-Wz-NeB" id="ObR-Gm-WrV"/>
                         <outlet property="resultTableView" destination="Nvp-PC-wLH" id="4pL-bM-8bo"/>
                     </connections>
                 </viewController>

--- a/groov/Common/Util/Constants.swift
+++ b/groov/Common/Util/Constants.swift
@@ -43,3 +43,8 @@ struct StoryboardId {
     static let Library = "SBIdLibrary"
 }
 
+struct Constants {
+    enum Layout {
+        
+    }
+}

--- a/groov/Common/Util/Debouncer.swift
+++ b/groov/Common/Util/Debouncer.swift
@@ -24,7 +24,7 @@ final class Debouncer {
         }
     }
     
-    private func resetTimer() {
+    func resetTimer() {
         if timer != nil {
             timer?.invalidate()
             timer = nil

--- a/groov/Common/Util/Debouncer.swift
+++ b/groov/Common/Util/Debouncer.swift
@@ -1,0 +1,33 @@
+//
+//  Debouncer.swift
+//  groov
+//
+//  Created by Kyujin Kim on 03/08/2019.
+//  Copyright © 2019 Mildwhale. All rights reserved.
+//
+import Foundation
+
+final class Debouncer {
+    private var interval: TimeInterval
+    private var timer: Timer?
+    
+    init(interval: TimeInterval) {
+        self.interval = interval
+    }
+    
+    func call(action: @escaping () -> Void) {
+        resetTimer()
+        DispatchQueue.main.async {
+            self.timer = Timer.scheduledTimer(withTimeInterval: self.interval, repeats: false, block: { (_) in
+                action()
+            })
+        }
+    }
+    
+    private func resetTimer() {
+        if timer != nil {
+            timer?.invalidate()
+            timer = nil
+        }
+    }
+}

--- a/groov/Common/Util/Extensions.swift
+++ b/groov/Common/Util/Extensions.swift
@@ -226,13 +226,3 @@ extension UIViewController {
         self.dismiss(animated: false, completion: nil)
     }
 }
-
-
-
-
-
-
-
-
-
-

--- a/groov/Controllers/SearchViewController.swift
+++ b/groov/Controllers/SearchViewController.swift
@@ -7,12 +7,8 @@
 //
 
 import UIKit
-import AssistantKit
-import Alamofire
-import SWXMLHash
-import RealmSwift
 
-protocol SearchViewControllerDelegate {
+protocol SearchViewControllerDelegate: class {
     func videoAdded(_ video: Video)
 }
 
@@ -23,21 +19,29 @@ extension Constants.Layout {
     }
 }
 
-class SearchViewController: BaseViewController {
-
+final class SearchViewController: BaseViewController {
+    enum SearchCellType {
+        case suggest, recently, searched
+    }
+    
     @IBOutlet var resultTableView: UITableView!
+    @IBOutlet var activityIndicatorView: UIActivityIndicatorView!
+
+    weak var delegate: SearchViewControllerDelegate?
     
-    lazy var searchBar: UISearchBar = UISearchBar(frame: CGRect(x: 0, y: 0, width: 100, height: 30))
-    var underLineView: UIImageView!
-    var isSearching: Bool = false
-    var shouldShowRecentVideo: Bool = true
-    var suggestResults: Array<String> = []
-    var videoResults: Array<Video> = []
-    var recentVideos: Array<Video> = []
-    var delegate: SearchViewControllerDelegate!
-    
-    private let debouncer: Debouncer = Debouncer(interval: 0.3)
-    private var nextPageToken: String?
+    private let searchBar: UISearchBar = UISearchBar(frame: CGRect(x: 0, y: 0, width: 100, height: 30))
+    private let underLineView: UIImageView = UIImageView(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+
+    private let dataManager: SearchViewDataManager = SearchViewDataManager()
+    private var showingCellType: SearchCellType {
+        if dataManager.searchedVideos.isEmpty == false {
+            return .searched
+        } else if dataManager.suggestions.isEmpty == false {
+            return .suggest
+        } else {
+            return .recently
+        }
+    }
     
     deinit {
         removeKeyboardNotification()
@@ -45,18 +49,85 @@ class SearchViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.setNavigationBarBackgroundColor()
-        self.initComponents()
-        self.getRecentAddedVideos()
-        self.addKeyboardNotification()
+        dataManager.delegate = self
+        
+        setNavigationBarBackgroundColor()
+        initComponents()
+        addKeyboardNotification()
     }
     
     func initComponents() {
-        self.initSearchBar()
-        self.initSearchBarTextField()
+        initSearchBar()
+        initSearchBarTextField()
         
-        self.view.backgroundColor = GRVColor.backgroundColor
-        self.resultTableView.backgroundColor = GRVColor.backgroundColor
+        view.backgroundColor = GRVColor.backgroundColor
+        resultTableView.backgroundColor = GRVColor.backgroundColor
+    }
+    
+    private func reloadTableView() {
+        switch showingCellType {
+        case .suggest:              resultTableView.separatorStyle = .none
+        case .recently, .searched:  resultTableView.separatorStyle = .singleLine
+        }
+        
+        resultTableView.reloadData()
+    }
+}
+
+// MARK: - Init Search Bar
+extension SearchViewController {
+    private func initSearchBar() {
+        searchBar.delegate = self
+        searchBar.placeholder = NSLocalizedString("SearchVideo", comment: "")
+        searchBar.showsCancelButton = true
+        searchBar.setImage(#imageLiteral(resourceName: "search_favicon"), for: .search, state: .normal)
+        searchBar.setImage(#imageLiteral(resourceName: "search_close"), for: .clear, state: .normal)
+        searchBar.searchBarStyle = .default
+        searchBar.barTintColor = .white
+        searchBar.sizeToFit()
+        navigationItem.titleView = searchBar
+        searchBar.becomeFirstResponder()
+        
+        var cancelButton: UIButton
+        let topView: UIView = searchBar.subviews[0] as UIView
+        for subView in topView.subviews {
+            if subView.isKind(of: NSClassFromString("UINavigationButton")!) {
+                cancelButton = subView as! UIButton
+                cancelButton.setTitle(NSLocalizedString("Close", comment: ""), for: .normal)
+                cancelButton.titleLabel?.font = UIFont.systemFont(ofSize: 15)
+                cancelButton.setTitleColor(GRVColor.mainTextColor, for: .normal)
+            }
+        }
+        
+        if let textField = firstSubview(of: UITextField.self, in: searchBar), let label = firstSubview(of: UILabel.self, in: searchBar) {
+            underLineView.translatesAutoresizingMaskIntoConstraints = false
+            underLineView.image = #imageLiteral(resourceName: "search_under_line")
+            underLineView.clipsToBounds = true
+            underLineView.contentMode = .scaleToFill
+            textField.addSubview(underLineView)
+            
+            underLineView.leadingAnchor.constraint(equalTo: textField.leadingAnchor, constant: label.frame.minX).isActive = true
+            let trailingConstraints = underLineView.trailingAnchor.constraint(equalTo: textField.trailingAnchor)
+            trailingConstraints.priority = .defaultHigh
+            trailingConstraints.isActive = true
+            underLineView.bottomAnchor.constraint(equalTo: textField.bottomAnchor).isActive = true
+            underLineView.heightAnchor.constraint(equalToConstant: 1.0).isActive = true
+        }
+    }
+    
+    private func firstSubview<T>(of type: T.Type, in view: UIView) -> T? {
+        return view.subviews.compactMap { $0 as? T ?? firstSubview(of: T.self, in: $0) }.first
+    }
+    
+    private func initSearchBarTextField() {
+        if let searchField = firstSubview(of: UITextField.self, in: searchBar) {
+            searchField.textColor = .white
+            searchField.tintColor = .white
+            searchField.backgroundColor = .clear
+            searchField.clearButtonMode = .whileEditing
+            searchField.autocorrectionType = .no
+            searchField.autocapitalizationType = .none
+        }
     }
 }
 
@@ -86,177 +157,55 @@ extension SearchViewController {
     }
 }
 
-// MARK: - Search Result, Recent Result, Auto Complete
-extension SearchViewController {
-    func getRecentAddedVideos() {
-        let realm = try! Realm()
-        self.recentVideos = Array(realm.objects(Video.self).sorted(byKeyPath: "createdAt", ascending: false))
-    }
-    
-    func getSuggestResult(keyword: String) {
-        self.isSearching = true
-        
-        SearchAPIHandler().requestSuggestion(of: keyword) { [weak self] result in
+// MARK: - SearchViewDataManagerDelegate
+extension SearchViewController: SearchViewDataManagerDelegate {
+    func suggestionsUpdated() {
+        DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
-            
-            switch result {
-            case .success(let suggestions):
-                self.suggestResults = suggestions
-                
-            case .failure(let error):
-                print(error.localizedDescription)
-            }
-            
-            DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
-                self.resultTableView.reloadData()
-            }
+            self.activityIndicatorView.stopAnimating()
+            self.reloadTableView()
         }
     }
     
-    func getVideoResult(_ searchText: String) {
-        self.isSearching = false
-        self.shouldShowRecentVideo = false
-
-        SearchAPIHandler().requestVideos(of: searchText) { [weak self] result in
+    func videoListUpdated(canRequestNextPage: Bool) {
+        DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
-            
-            switch result {
-            case .success(let data):
-                self.videoResults.removeAll()
-                self.videoResults.append(contentsOf: data.videos)
-                self.nextPageToken = data.token
-                
-            case .failure(let error):
-                print(error.localizedDescription)
-            }
-            
-            DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
-                
-                if self.nextPageToken == nil {
-                    self.resultTableView.tableFooterView = nil
-                } else {
-                    self.resultTableView.tableFooterView = LoadingIndicatorView()
-                }
-                
-                self.resultTableView.reloadData()
-            }
+            self.activityIndicatorView.stopAnimating()
+            self.resultTableView.tableFooterView = canRequestNextPage ? LoadingIndicatorView() : nil
+            self.reloadTableView()
         }
     }
     
-    private func getNextPageVideos(_ suggestion: String, token: String) {
-        SearchAPIHandler().requestVideos(of: suggestion, token: token) { [weak self] result in
+    func error(api: YoutubeAPI, error: Error) {
+        print(error.localizedDescription)
+        DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
-            
-            switch result {
-            case .success(let data):
-                var newVideos = self.videoResults
-                newVideos.append(contentsOf: data.videos)
-                self.videoResults = newVideos
-                self.nextPageToken = data.token
-                
-            case .failure(let error):
-                print(error.localizedDescription)
-            }
-            
-            DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
-                
-                if self.nextPageToken == nil {
-                    self.resultTableView.tableFooterView = nil
-                } else {
-                    self.resultTableView.tableFooterView = LoadingIndicatorView()
-                }
-                
-                self.resultTableView.reloadData()
-            }
-        }
-    }
-}
-
-// MARK: - Init Search Bar
-extension SearchViewController {
-    
-    func initSearchBar() {
-        self.searchBar.delegate = self
-        self.searchBar.placeholder = NSLocalizedString("SearchVideo", comment: "")
-        self.searchBar.showsCancelButton = true
-        self.searchBar.setImage(#imageLiteral(resourceName: "search_favicon"), for: .search, state: .normal)
-        self.searchBar.setImage(#imageLiteral(resourceName: "search_close"), for: .clear, state: .normal)
-        self.searchBar.searchBarStyle = .default
-        self.searchBar.barTintColor = .white
-        self.searchBar.sizeToFit()
-        self.navigationItem.titleView = self.searchBar
-        self.searchBar.becomeFirstResponder()
-        
-        var cancelButton: UIButton
-        let topView: UIView = self.searchBar.subviews[0] as UIView
-        for subView in topView.subviews {
-            if subView.isKind(of: NSClassFromString("UINavigationButton")!) {
-                cancelButton = subView as! UIButton
-                cancelButton.setTitle(NSLocalizedString("Close", comment: ""), for: .normal)
-                cancelButton.titleLabel?.font = UIFont.systemFont(ofSize: 15)
-                cancelButton.setTitleColor(GRVColor.mainTextColor, for: .normal)
-            }
-        }
-        
-        if let textField = firstSubview(of: UITextField.self, in: searchBar), let label = firstSubview(of: UILabel.self, in: searchBar) {
-            underLineView = UIImageView(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
-            underLineView.translatesAutoresizingMaskIntoConstraints = false
-            underLineView.image = #imageLiteral(resourceName: "search_under_line")
-            underLineView.clipsToBounds = true
-            underLineView.contentMode = .scaleToFill
-            textField.addSubview(underLineView)
-            
-            underLineView.leadingAnchor.constraint(equalTo: textField.leadingAnchor, constant: label.frame.minX).isActive = true
-            let trailingConstraints = underLineView.trailingAnchor.constraint(equalTo: textField.trailingAnchor)
-            trailingConstraints.priority = .defaultHigh
-            trailingConstraints.isActive = true
-            underLineView.bottomAnchor.constraint(equalTo: textField.bottomAnchor).isActive = true
-            underLineView.heightAnchor.constraint(equalToConstant: 1.0).isActive = true
-        }
-    }
-    
-    func firstSubview<T>(of type: T.Type, in view: UIView) -> T? {
-        return view.subviews.compactMap { $0 as? T ?? firstSubview(of: T.self, in: $0) }.first
-    }
-    
-    func initSearchBarTextField() {
-        if let searchField = firstSubview(of: UITextField.self, in: searchBar) {
-            searchField.textColor = .white
-            searchField.tintColor = .white
-            searchField.backgroundColor = .clear
-            searchField.clearButtonMode = .whileEditing
-            searchField.autocorrectionType = .no
-            searchField.autocapitalizationType = .none
+            self.activityIndicatorView.stopAnimating()
         }
     }
 }
 
 // MARK: - UISearchBarDelegate
 extension SearchViewController: UISearchBarDelegate {
-    
     func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
-        self.dismiss(animated: true, completion: nil)
+        dismiss(animated: true, completion: nil)
     }
     
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
-        self.getVideoResult(searchBar.text!)
+        activityIndicatorView.startAnimating()
+        dataManager.requestSuggestionList(keyword: searchBar.text!)
     }
     
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        if searchText.replacingOccurrences(of: " ", with: "") == "" {
-            self.shouldShowRecentVideo = true
-            self.isSearching = false
-            self.getRecentAddedVideos()
-            self.resultTableView.reloadData()
+        let trimmedText = searchText.trimmingCharacters(in: .whitespaces)
+        dataManager.requestSuggestionList(keyword: trimmedText)
+        
+        if trimmedText.isEmpty {
+            dataManager.updateRecentlyAddedVideos()
+            reloadTableView()
         } else {
-            debouncer.call {
-                self.getSuggestResult(keyword: searchText)
-            }
+            activityIndicatorView.startAnimating()
         }
-
         resultTableView.tableFooterView = nil
     }
 }
@@ -264,35 +213,31 @@ extension SearchViewController: UISearchBarDelegate {
 // MARK: - UITableViewDataSource
 extension SearchViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if self.isSearching == false {
-            self.resultTableView.separatorStyle = .singleLine
-            if self.shouldShowRecentVideo == true {
-                return self.recentVideos.count
-            } else {
-                return self.videoResults.count
-            }
+        switch showingCellType {
+        case .suggest:  return dataManager.suggestions.count
+        case .recently: return dataManager.recentlyAddedVideos.count
+        case .searched: return dataManager.searchedVideos.count
         }
-        
-        self.resultTableView.separatorStyle = .none
-        return self.suggestResults.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if self.isSearching { // auto-complete, is searching
-            let cellIdentifier: String = "SearchSuggestCellIdentifier"
-            let cell: SearchSuggestTableViewCell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath) as! SearchSuggestTableViewCell
-            cell.initCell(self.suggestResults[indexPath.row])
+        switch showingCellType {
+        case .suggest:
+            let reuseIdentifier = "SearchSuggestCellIdentifier"
+            let cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier, for: indexPath)
+            if let suggestCell = cell as? SearchSuggestTableViewCell {
+                suggestCell.initCell(dataManager.suggestions[indexPath.row])
+            }
+            return cell
+            
+        case .recently, .searched:
+            let reuseIdentifier = "SearchVideoCellIdentifier"
+            let cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier, for: indexPath)
+            if let videoCell = cell as? SearchVideoTableViewCell, let video = dataManager.video(at: indexPath) {
+                videoCell.initCell(video)
+            }
             return cell
         }
-        
-        let cellIdentifier: String = "SearchVideoCellIdentifier"
-        let cell: SearchVideoTableViewCell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath) as! SearchVideoTableViewCell
-        if shouldShowRecentVideo == true { // show recent videos
-            cell.initCell(self.recentVideos[indexPath.row])
-        } else { // show search result videos
-            cell.initCell(self.videoResults[indexPath.row])
-        }
-        return cell
     }
 }
 
@@ -303,28 +248,41 @@ extension SearchViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return isSearching ? Constants.Layout.SearchList.heightForSuggest : Constants.Layout.SearchList.heightForVideo
+        switch showingCellType {
+        case .suggest:              return Constants.Layout.SearchList.heightForSuggest
+        case .recently, .searched:  return Constants.Layout.SearchList.heightForVideo
+        }
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         
-        if isSearching {
-            let keyword = suggestResults[indexPath.row]
+        switch showingCellType {
+        case .suggest:
+            let keyword = dataManager.suggestions[indexPath.row]
             searchBar.text = keyword
-            getVideoResult(keyword)
-        } else {
-            let targetVideo = shouldShowRecentVideo ? recentVideos[indexPath.row] : videoResults[indexPath.row]
-            delegate.videoAdded(targetVideo)
+            activityIndicatorView.startAnimating()
+            dataManager.requestVideos(suggestion: keyword)
+            
+        case .recently, .searched:
+            var targetVideo: Video {
+                if dataManager.searchedVideos.isEmpty == false {
+                    return dataManager.searchedVideos[indexPath.row]
+                } else {
+                    return dataManager.recentlyAddedVideos[indexPath.row]
+                }
+            }
+            delegate?.videoAdded(targetVideo)
         }
     }
     
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        guard showingCellType == .searched else { return }
+        
         if cell is SearchVideoTableViewCell {
-            let isLastCell = indexPath.row == (videoResults.count - 1)
-            if isLastCell, let suggestion = searchBar.text, let token = nextPageToken {
-                nextPageToken = nil
-                getNextPageVideos(suggestion, token: token)
+            let isLastCell = indexPath.row == (dataManager.searchedVideos.count - 1)
+            if isLastCell, let suggestion = searchBar.text {
+                dataManager.requestNextPageIfAvailable(suggestion: suggestion)
             }
         }
     }

--- a/groov/SearchHelper/SearchAPIHandler.swift
+++ b/groov/SearchHelper/SearchAPIHandler.swift
@@ -11,50 +11,50 @@ import Moya
 import SWXMLHash
 
 final class SearchAPIHandler {
-    typealias SuggestionCompletionHandler = ([String]) -> ()
-    typealias GetVideosCompletionHandler = ([Video]) -> ()
+    typealias GetVideoSuccessResult = (videos: [Video], token: String?)
     
-    private let kAPIKeyYoutube: String = Bundle.main.object(forInfoDictionaryKey: "YoutubeAPIKey") as! String
+    typealias SuggestionCompletionHandler = (Result<[String], Error>) -> ()
+    typealias GetVideosCompletionHandler = (Result<GetVideoSuccessResult, Error>) -> ()
+
     private let provider = MoyaProvider<YoutubeAPI>(plugins: [NetworkLoggerPlugin()])
-    
-    private var latestSuggestion: String? {
-        didSet {
-            if oldValue != latestSuggestion {
-                nextPageToken = nil
-            }
-        }
-    }
-    // TODO: pageToken & Pagination
-    private var nextPageToken: String?
     
     // MARK: - Function
     func requestSuggestion(of keyword: String, completionHandler: @escaping SuggestionCompletionHandler) {
         provider.request(.suggestion(keyword: keyword)) { result in
-            var suggestions: [String] = []
             
             switch result {
             case .success(let response):
+                var suggestions: [String] = []
+                
                 SWXMLHash.parse(response.data)["toplevel"]["CompleteSuggestion"].all.forEach {
                     guard let element = $0["suggestion"].element, let data = element.attribute(by: "data") else { return }
                     suggestions.append(data.text)
                 }
                 
+                completionHandler(.success(suggestions))
+                
             case .failure(let error):
-                print(error.localizedDescription)
+                completionHandler(.failure(error))
             }
-            
-            completionHandler(suggestions)
         }
     }
     
-    func requestVideos(of suggestion: String, completionHandler: @escaping GetVideosCompletionHandler) {
-        provider.request(.search(suggestion: suggestion, apiKey: kAPIKeyYoutube)) { result in
+    func requestVideos(of suggestion: String, token: String? = nil, completionHandler: @escaping GetVideosCompletionHandler) {
+        var api: YoutubeAPI {
+            if let token = token {
+                return .pagination(suggestion: suggestion, token: token)
+            }
+            return .videoId(suggestion: suggestion)
+        }
+        
+        provider.request(api) { result in
             switch result {
             case .success(let response):
                 do {
+                    var nextPageToken: String?
+                    var ids: [String] = []
+
                     if let json = try response.mapJSON() as? [String: Any] {
-                        var ids: [String] = []
-                        
                         if let items = json["items"] as? [[String: AnyObject]] {
                             items.forEach {
                                 if let videoId = $0["id"] as? [String: AnyObject], let id = videoId["videoId"] as? String {
@@ -62,29 +62,27 @@ final class SearchAPIHandler {
                                 }
                             }
                         }
-                        
-                        self.requestVideos(of: ids, completionHandler: completionHandler)
-                        return
+                        nextPageToken = json["nextPageToken"] as? String
                     }
-                } catch let error as NSError {
-                    print(error.localizedDescription)
+                    
+                    self.requestVideos(with: ids, token: nextPageToken, completionHandler: completionHandler)
+                } catch {
+                    completionHandler(.failure(error))
                 }
                 
             case .failure(let error):
-                print(error.localizedDescription)
+                completionHandler(.failure(error))
             }
-            
-            completionHandler([])
         }
     }
     
-    private func requestVideos(of videoIds: [String], completionHandler: @escaping GetVideosCompletionHandler) {
-        provider.request(.videos(ids: videoIds, apiKey: kAPIKeyYoutube)) { result in
-            var videos: [Video] = []
-            
+    private func requestVideos(with ids: [String], token: String?, completionHandler: @escaping GetVideosCompletionHandler) {
+        provider.request(.videoList(ids: ids)) { result in
             switch result {
             case .success(let response):
                 do {
+                    var videos: [Video] = []
+                    
                     if let json = try response.mapJSON() as? [String: Any] {
                         if let items = json["items"] as? [[String: AnyObject]] {
                             items.forEach {
@@ -93,17 +91,15 @@ final class SearchAPIHandler {
                         }
                     }
                     
-                    completionHandler(videos)
-                    return
-                } catch let error as NSError {
-                    print(error.localizedDescription)
+                    let result = (videos, token)
+                    completionHandler(.success(result))
+                } catch {
+                    completionHandler(.failure(error))
                 }
                 
             case .failure(let error):
-                print(error.localizedDescription)
+                completionHandler(.failure(error))
             }
-            
-            completionHandler(videos)
         }
     }
 }

--- a/groov/SearchHelper/SearchViewDataManager.swift
+++ b/groov/SearchHelper/SearchViewDataManager.swift
@@ -1,0 +1,159 @@
+//
+//  SearchViewDataManager.swift
+//  groov
+//
+//  Created by Kyujin Kim on 2020/02/24.
+//  Copyright © 2020 Mildwhale. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+import Moya
+
+protocol SearchViewDataManagerDelegate: class {
+    func suggestionsUpdated()
+    func videoListUpdated(canRequestNextPage: Bool)
+    func error(api: YoutubeAPI, error: Error)
+}
+
+final class SearchViewDataManager {
+    // MARK: - Value
+    // MARK: Public
+    var suggestions: [String] = [] {
+        didSet {
+            if oldValue != suggestions {
+                delegate?.suggestionsUpdated()
+            }
+        }
+    }
+    var recentlyAddedVideos: [Video] = []
+    var searchedVideos: [Video] = [] {
+        didSet {
+            if oldValue != searchedVideos {
+                delegate?.videoListUpdated(canRequestNextPage: nextPageToken != nil)
+            }
+        }
+    }
+    
+    weak var delegate: SearchViewDataManagerDelegate?
+    
+    // MARK: Private
+    private let debouncer: Debouncer = Debouncer(interval: 0.3)
+    private var nextPageToken: String?
+    
+    private var cancellables: [Cancellable] = []
+    
+    // MARK: - Function
+    // MARK: Public
+    init() {
+        updateRecentlyAddedVideos()
+    }
+    
+    func video(at indexPath: IndexPath) -> Video? {
+        if searchedVideos.isEmpty == false, indexPath.row < searchedVideos.count {
+            return searchedVideos[indexPath.row]
+        } else if recentlyAddedVideos.isEmpty == false, indexPath.row < recentlyAddedVideos.count {
+            return recentlyAddedVideos[indexPath.row]
+        }
+        return nil
+    }
+    
+    func updateRecentlyAddedVideos() {
+        let realm = try! Realm()
+        recentlyAddedVideos = Array(realm.objects(Video.self).sorted(byKeyPath: "createdAt", ascending: false))
+    }
+    
+    func requestSuggestionList(keyword: String) {
+        cancelAllRequest()
+        nextPageToken = nil
+        suggestions = []
+        searchedVideos = []
+        
+        let trimmedString = keyword.trimmingCharacters(in: .whitespaces)
+        guard trimmedString.isEmpty == false else {
+            debouncer.resetTimer()
+            return
+        }
+        
+        debouncer.call { [weak self] in
+            guard let self = self else { return }
+            
+            let cancellable = SearchAPIHandler().requestSuggestion(of: keyword) { [weak self] result in
+                guard let self = self else { return }
+                switch result {
+                case .success(let suggestions):
+                    self.suggestions = suggestions
+                    
+                case .failure(let error):
+                    self.delegate?.error(api: .suggestion(keyword: keyword), error: error)
+                }
+            }
+            self.cancellables.append(cancellable)
+        }
+    }
+    
+    func requestVideos(suggestion: String) {
+        requestVideos(suggestion: suggestion, token: nil)
+    }
+    
+    func requestNextPageIfAvailable(suggestion: String) {
+        guard let token = nextPageToken else { return }
+        nextPageToken = nil
+        
+        requestVideos(suggestion: suggestion, token: token)
+    }
+    
+    // MARK: Private
+    private func cancelAllRequest() {
+        cancellables.forEach {
+            if $0.isCancelled == false {
+                $0.cancel()
+            }
+        }
+        cancellables.removeAll()
+    }
+    
+    private func requestVideos(suggestion: String, token: String?) {
+        let cancellable = SearchAPIHandler().requestVideoIds(of: suggestion, token: token) { [weak self] result in
+            guard let self = self else { return }
+            
+            switch result {
+            case .success(let data):
+                self.nextPageToken = data.token
+                self.requestVideos(ids: data.ids, token: token)
+                
+            case .failure(let error):
+                var api: YoutubeAPI {
+                    if let token = token {
+                        return .pagination(suggestion: suggestion, token: token)
+                    }
+                    return .videoId(suggestion: suggestion)
+                }
+                self.delegate?.error(api: api, error: error)
+            }
+        }
+        cancellables.append(cancellable)
+    }
+    
+    private func requestVideos(ids: [String], token: String?) {
+        let cancellable = SearchAPIHandler().requestVideos(with: ids) { [weak self] result in
+            guard let self = self else { return }
+            
+            switch result {
+            case .success(let videos):
+                var newVideos: [Video] = []
+                if token == nil {
+                    newVideos = videos
+                } else {
+                    newVideos = self.searchedVideos
+                    newVideos.append(contentsOf: videos)
+                }
+                self.searchedVideos = newVideos
+                
+            case .failure(let error):
+                self.delegate?.error(api: .videoList(ids: ids), error: error)
+            }
+        }
+        cancellables.append(cancellable)
+    }
+}

--- a/groov/SearchHelper/YoutubeAPI.swift
+++ b/groov/SearchHelper/YoutubeAPI.swift
@@ -74,7 +74,7 @@ extension YoutubeAPI: TargetType {
             return .requestPlain
             
         case .pagination(let suggestion, let token):
-            let encodable = YoutubeSearchParameter(q: suggestion, key: YoutubeAPI.key, paginationToken: token)
+            let encodable = YoutubeSearchParameter(q: suggestion, key: YoutubeAPI.key, pageToken: token)
             if let dictionary = encodable.dictionary {
                 return .requestParameters(parameters: dictionary, encoding: URLEncoding.default)
             }
@@ -99,7 +99,7 @@ private struct YoutubeSearchParameter: Encodable {
     let maxResults: Int = 10
     let q: String
     let key: String
-    var paginationToken: String?
+    var pageToken: String?
 }
 
 private struct YoutubeVideosParameter: Encodable {

--- a/groov/SearchHelper/YoutubeAPI.swift
+++ b/groov/SearchHelper/YoutubeAPI.swift
@@ -11,17 +11,20 @@ import Moya
 
 enum YoutubeAPI {
     case suggestion(keyword: String)
-    case search(suggestion: String, apiKey: String)
-    case videos(ids: [String], apiKey: String)
+    case videoId(suggestion: String)
+    case videoList(ids: [String])
+    case pagination(suggestion: String, token: String)
 }
 
 extension YoutubeAPI: TargetType {
+    static let key = Bundle.main.object(forInfoDictionaryKey: "YoutubeAPIKey") as! String
+    
     var baseURL: URL {
         switch self {
         case .suggestion:
             return URL(string: "http://google.com")!
             
-        case .search, .videos:
+        case .videoId, .videoList, .pagination:
             return URL(string: "https://www.googleapis.com")!
         }
     }
@@ -31,10 +34,10 @@ extension YoutubeAPI: TargetType {
         case .suggestion:
             return "/complete/search"
             
-        case .search:
+        case .videoId, .pagination:
             return "/youtube/v3/search"
             
-        case .videos:
+        case .videoList:
             return "/youtube/v3/videos"
         }
     }
@@ -56,15 +59,22 @@ extension YoutubeAPI: TargetType {
             }
             return .requestPlain
             
-        case .search(let suggestion, let apiKey):
-            let encodable = YoutubeSearchParameter(q: suggestion, key: apiKey)
+        case .videoId(let suggestion):
+            let encodable = YoutubeSearchParameter(q: suggestion, key: YoutubeAPI.key)
             if let dictionary = encodable.dictionary {
                 return .requestParameters(parameters: dictionary, encoding: URLEncoding.default)
             }
             return .requestPlain
 
-        case .videos(let ids, let apiKey):
-            let encodable = YoutubeVideosParameter(ids: ids, apiKey: apiKey)
+        case .videoList(let ids):
+            let encodable = YoutubeVideosParameter(ids: ids, apiKey: YoutubeAPI.key)
+            if let dictionary = encodable.dictionary {
+                return .requestParameters(parameters: dictionary, encoding: URLEncoding.default)
+            }
+            return .requestPlain
+            
+        case .pagination(let suggestion, let token):
+            let encodable = YoutubeSearchParameter(q: suggestion, key: YoutubeAPI.key, paginationToken: token)
             if let dictionary = encodable.dictionary {
                 return .requestParameters(parameters: dictionary, encoding: URLEncoding.default)
             }
@@ -89,6 +99,7 @@ private struct YoutubeSearchParameter: Encodable {
     let maxResults: Int = 10
     let q: String
     let key: String
+    var paginationToken: String?
 }
 
 private struct YoutubeVideosParameter: Encodable {

--- a/groov/Views/LoadingIndicatorView.swift
+++ b/groov/Views/LoadingIndicatorView.swift
@@ -1,0 +1,46 @@
+//
+//  LoadingIndicatorView.swift
+//  groov
+//
+//  Created by Kyujin Kim on 2020/02/22.
+//  Copyright © 2020 Mildwhale. All rights reserved.
+//
+
+import UIKit
+
+final class LoadingIndicatorView: UIView {
+    private let activityIndicatorView = UIActivityIndicatorView(style: .white)
+    
+    override init(frame: CGRect) {
+        let width = UIScreen.main.bounds.width
+        let height = Constants.Layout.SearchList.heightForSuggest
+        
+        super.init(frame: CGRect(x: 0, y: 0, width: width, height: height))
+        initialize()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        initialize()
+    }
+    
+    func initialize() {
+        addSubview()
+        layout()
+        style()
+    }
+    
+    func addSubview() {
+        addSubview(activityIndicatorView)
+    }
+    
+    func layout() {
+        activityIndicatorView.center = center
+    }
+    
+    func style() {
+        backgroundColor = GRVColor.backgroundColor
+        
+        activityIndicatorView.startAnimating()
+    }
+}


### PR DESCRIPTION
SearchViewController의 네트워크 및 데이터 로직을 분리하면서 많은 부분이 수정되었습니다.
기본적인 동작 및 예외는 확인했으나, 걸러지지 않은 이슈가 있을 수 있으니 확인 부탁드려요.

앱스토어 배포 한번 해도 좋을 것 같은데, 지금 사용하고 있는 YoutubePlayer가 UIWebView를 사용중이어서 배포가 될지 모르겠습니다.

## 주요 수정사항
* 비디오 목록 페이지네이션 구현.
* SearchViewController의 네트워크 및 데이터 관리 로직 분리.

## 세부 수정사항
♻️ 페이지네이션 기능 구현을 위해 APIHandler에 Result를 적용함.
🎨 비디오 결과 목록 하단에 로딩 뷰 추가.
✨ 페이지네이션 구현.
✨ 검색 화면의 데이터를 담당하는 SearchViewDataManager 클래스 추가.
♻️ 검색 화면의 데이터를 분리하고, 네트워크 리퀘스트 로직 및 테이블 뷰 관리하는 로직을 리팩토링함.
💄 Suggestion 및 video 목록 검색 시 ActivityIndicatorView 노출.