### PR TITLE
프레젠테이션 스타일을 FullScreen으로 변경

### DIFF
--- a/groov/Controllers/PlaylistListViewController.swift
+++ b/groov/Controllers/PlaylistListViewController.swift
@@ -114,6 +114,7 @@ extension PlaylistListViewController {
     @IBAction func showSettingsVC() {
         let settingsVC = self.storyboard?.instantiateViewController(withIdentifier: StoryboardId.Settings) as! SettingsViewController
         let navController = UINavigationController.init(rootViewController: settingsVC)
+        navController.modalPresentationStyle = .fullScreen
         self.present(navController, animated: true, completion: nil)
     }
 }

--- a/groov/Controllers/SearchViewController.swift
+++ b/groov/Controllers/SearchViewController.swift
@@ -98,6 +98,7 @@ extension SearchViewController {
                 cancelButton.setTitleColor(GRVColor.mainTextColor, for: .normal)
             }
         }
+        searchBar.layoutIfNeeded() // Layout을 안해주면 TextField가 그려지기 전이라, Underline을 붙일 수 없음.
         
         if let textField = firstSubview(of: UITextField.self, in: searchBar), let label = firstSubview(of: UILabel.self, in: searchBar) {
             underLineView.translatesAutoresizingMaskIntoConstraints = false

--- a/groov/Controllers/SettingsViewController.swift
+++ b/groov/Controllers/SettingsViewController.swift
@@ -94,6 +94,7 @@ extension SettingsViewController {
     
     func sendMail() {
         let mailVC = MFMailComposeViewController()
+        mailVC.modalPresentationStyle = .fullScreen
         mailVC.mailComposeDelegate = self
         mailVC.setToRecipients(["rlavlfrnjs12@gmail.com"])
         mailVC.setSubject("Service feedback for groov")

--- a/groov/Controllers/VideoListViewController.swift
+++ b/groov/Controllers/VideoListViewController.swift
@@ -355,6 +355,7 @@ extension VideoListViewController {
         let searchVC = self.storyboard?.instantiateViewController(withIdentifier: StoryboardId.Search) as! SearchViewController
         searchVC.delegate = self
         let navController = UINavigationController(rootViewController: searchVC)
+        navController.modalPresentationStyle = .fullScreen
         self.present(navController, animated: true, completion: nil)
     }
     


### PR DESCRIPTION
## 수정사항
:lipstick: 검색, 설정, 이메일 전송 화면의 PresentationStyle을 FullScreen으로 변경했습니다.
:bug: PresentationStyle을 변경하면 SearchBar의 Underline이 그려지지 않는 이슈를 수정했습니다.

resolve #7 