### PR TITLE
:arrow_up: GROOV 1.3.6

### DIFF
--- a/groov/Resources/Info.plist
+++ b/groov/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.4</string>
+	<string>1.3.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1582695905</string>
+	<string>1583014160</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/groovSnapshot/Info.plist
+++ b/groovSnapshot/Info.plist
@@ -15,8 +15,8 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.5</string>
+	<string>1.3.6</string>
 	<key>CFBundleVersion</key>
-	<string>1582819414</string>
+	<string>1583014160</string>
 </dict>
 </plist>


### PR DESCRIPTION
GROOV 1.3.6 변경사항
- #27 XCConfig 적용
- #28 사용하지 않는 Pod 제거
- #29 문법 정리
- #32 UIWebView 지원 중단
- #33 LibrariesWeUse 제거
- #35 코드 기반 레이아웃 적용
- #38 런치 스크린 이미지 되살리기
- #39 잃어버린 리드미 이미지 되살리기
- #31 YoutubeKit 적용
- #44 Video 전체화면 지원
- #45 이미지 리터럴 제거
- #46 현재 재생중인 영상 삭제하면 첫 번째 영상이 선택되도록 변경
- #47, #48 비디오의 duration 정보를 못 불러올 경우 progress가 nan이 되는 경우 예외 처리
