### PR TITLE
:sparkles: 비디오의 duration 정보 못 불러올 경우 예외 처리

### DIFF
--- a/groov/Sources/Controller/VideoListViewController.swift
+++ b/groov/Sources/Controller/VideoListViewController.swift
@@ -534,6 +534,7 @@ extension VideoListViewController: UITableViewDelegate {
                 let currentIndex = tableView.indexPath(for: cell),
                 currentIndex == indexPath {
                 currentSelectedCell = nil
+                videoPlayer.stopVideo()
                 if videos.count > currentIndex.row {
                     nextIndex = currentIndex.row
                 } else if !videos.isEmpty {
@@ -579,7 +580,9 @@ extension VideoListViewController {
         let progress: CGFloat = CGFloat(currentTime) / CGFloat(videoDuration)
         
         runningTimeLabel.text = "\(currentTimeString) / \(videoDurationString)"
-        progressImageViewWidth?.update(offset: progress * view.bounds.width)
+        if progress != .nan {
+            progressImageViewWidth?.update(offset: progress * view.bounds.width)
+        }
         
         UIView.animate(withDuration: 0.5, animations: { [weak self] in
             guard let self = self else { return }


### PR DESCRIPTION
가끔씩 videoPlayer가 초기화되기 전에 비디오를 불러오면 비디오의 duration 정보를 0으로 가져와서 progress가 0/0 계산때문에 nan이 되는 경우가 있습니다.
이를 방지하도록 수정했습니다.

resolve #42