### PR TITLE
SPM 적용

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,4 @@
 PODS:
-  - Alamofire (5.0.2)
   - Crashlytics (3.9.3):
     - Fabric (~> 1.7.2)
   - Fabric (1.7.13)
@@ -100,14 +99,6 @@ PODS:
   - GoogleUtilities/UserDefaults (6.5.1):
     - GoogleUtilities/Logger
   - GTMSessionFetcher/Core (1.3.1)
-  - KDCircularProgress (1.5.4)
-  - Kingfisher (5.13.2):
-    - Kingfisher/Core (= 5.13.2)
-  - Kingfisher/Core (5.13.2)
-  - Moya (14.0.0):
-    - Moya/Core (= 14.0.0)
-  - Moya/Core (14.0.0):
-    - Alamofire (~> 5.0)
   - nanopb (0.3.9011):
     - nanopb/decode (= 0.3.9011)
     - nanopb/encode (= 0.3.9011)
@@ -115,22 +106,9 @@ PODS:
   - nanopb/encode (0.3.9011)
   - PromisesObjC (1.2.8)
   - Protobuf (3.11.4)
-  - Realm (4.3.2):
-    - Realm/Headers (= 4.3.2)
-  - Realm/Headers (4.3.2)
-  - RealmSwift (4.3.2):
-    - Realm (= 4.3.2)
-  - RxCocoa (5.0.1):
-    - RxRelay (~> 5)
-    - RxSwift (~> 5)
-  - RxRelay (5.0.1):
-    - RxSwift (~> 5)
-  - RxSwift (5.0.1)
-  - SnapKit (5.0.1)
   - SwiftMessages (7.0.1):
     - SwiftMessages/App (= 7.0.1)
   - SwiftMessages/App (7.0.1)
-  - SWXMLHash (5.0.1)
   - YoutubeKit (0.4.1)
 
 DEPENDENCIES:
@@ -138,20 +116,11 @@ DEPENDENCIES:
   - Fabric (~> 1.7.2)
   - Firebase/Core
   - Firebase/Performance
-  - KDCircularProgress (~> 1.5.4)
-  - Kingfisher (~> 5.0)
-  - Moya (~> 14.0)
-  - RealmSwift
-  - RxCocoa (~> 5)
-  - RxSwift (~> 5)
-  - SnapKit (~> 5.0.0)
   - SwiftMessages (~> 7.0.0)
-  - SWXMLHash (~> 5.0.0)
   - YoutubeKit (from `https://github.com/mildwhale/YoutubeKit.git`, tag `0.4.2`)
 
 SPEC REPOS:
   trunk:
-    - Alamofire
     - Crashlytics
     - Fabric
     - Firebase
@@ -171,20 +140,10 @@ SPEC REPOS:
     - GoogleToolboxForMac
     - GoogleUtilities
     - GTMSessionFetcher
-    - KDCircularProgress
-    - Kingfisher
-    - Moya
     - nanopb
     - PromisesObjC
     - Protobuf
-    - Realm
-    - RealmSwift
-    - RxCocoa
-    - RxRelay
-    - RxSwift
-    - SnapKit
     - SwiftMessages
-    - SWXMLHash
 
 EXTERNAL SOURCES:
   YoutubeKit:
@@ -197,7 +156,6 @@ CHECKOUT OPTIONS:
     :tag: 0.4.2
 
 SPEC CHECKSUMS:
-  Alamofire: 3ba7a4db18b4f62c4a1c0e1cb39d7f3d52e10ada
   Crashlytics: dbb07d01876c171c5ccbdf7826410380189e452c
   Fabric: 25d0963b691fc97be566392243ff0ecef5a68338
   Firebase: 0490eca762a72e4f1582319539153897f1508dee
@@ -217,22 +175,12 @@ SPEC CHECKSUMS:
   GoogleToolboxForMac: 800648f8b3127618c1b59c7f97684427630c5ea3
   GoogleUtilities: 06eb53bb579efe7099152735900dd04bf09e7275
   GTMSessionFetcher: cea130bbfe5a7edc8d06d3f0d17288c32ffe9925
-  KDCircularProgress: 98200c6b8e85d22bc04eb644721d3b1e12b0686b
-  Kingfisher: d342c8354c10c3d85a27d6d4c42c41285924b898
-  Moya: 5b45dacb75adb009f97fde91c204c1e565d31916
   nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
   PromisesObjC: c119f3cd559f50b7ae681fa59dc1acd19173b7e6
   Protobuf: 176220c526ad8bd09ab1fb40a978eac3fef665f7
-  Realm: 5e92902e2875dff4bb0fd02f67bb737c3d5db2bc
-  RealmSwift: 9a360fc7bae04fc2e308a34fbd899d5faa2d6b22
-  RxCocoa: e741b9749968e8a143e2b787f1dfbff2b63d0a5c
-  RxRelay: 89d54507f4fd4d969e6ec1d4bd7f3673640b4640
-  RxSwift: e2dc62b366a3adf6a0be44ba9f405efd4c94e0c4
-  SnapKit: 97b92857e3df3a0c71833cce143274bf6ef8e5eb
   SwiftMessages: b577dc7043be8b299857ab35bb663dbff6483bd0
-  SWXMLHash: 9cc0c2e4807926c74377724aa8722ee5707a0485
   YoutubeKit: d1f99c47f200ef500462352f516043bd7c08728f
 
-PODFILE CHECKSUM: f622df62f4befaf46effac9570fe44f0f9c47c2c
+PODFILE CHECKSUM: 18625e57d4f8118872e4807bc02c0dede5467029
 
 COCOAPODS: 1.9.0

--- a/groov.xcodeproj/project.pbxproj
+++ b/groov.xcodeproj/project.pbxproj
@@ -34,15 +34,15 @@
 		1F9648AE240AE85E002D9FDA /* SettingsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9648AD240AE85E002D9FDA /* SettingsTableViewCell.swift */; };
 		1F9648B0240AEE30002D9FDA /* PlaylistFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9648AF240AEE30002D9FDA /* PlaylistFooterView.swift */; };
 		1F9648B6240B144F002D9FDA /* BlankView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9648B5240B144F002D9FDA /* BlankView.swift */; };
-		1FD8CAB0241026770085C18E /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAAF241026770085C18E /* SwiftPackageProductDependency */; };
-		1FD8CAB2241026770085C18E /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAB1241026770085C18E /* SwiftPackageProductDependency */; };
-		1FD8CAB5241026B00085C18E /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAB4241026B00085C18E /* SwiftPackageProductDependency */; };
-		1FD8CAB8241027180085C18E /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAB7241027180085C18E /* SwiftPackageProductDependency */; };
-		1FD8CABB241027410085C18E /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CABA241027410085C18E /* SwiftPackageProductDependency */; };
-		1FD8CABE241027620085C18E /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CABD241027620085C18E /* SwiftPackageProductDependency */; };
-		1FD8CAC1241028140085C18E /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAC0241028140085C18E /* SwiftPackageProductDependency */; };
-		1FD8CAC3241028140085C18E /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAC2241028140085C18E /* SwiftPackageProductDependency */; };
-		1FD8CAC6241028C10085C18E /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAC5241028C10085C18E /* SwiftPackageProductDependency */; };
+		1FD8CAB0241026770085C18E /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAAF241026770085C18E /* Realm */; };
+		1FD8CAB2241026770085C18E /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAB1241026770085C18E /* RealmSwift */; };
+		1FD8CAB5241026B00085C18E /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAB4241026B00085C18E /* Kingfisher */; };
+		1FD8CAB8241027180085C18E /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAB7241027180085C18E /* Moya */; };
+		1FD8CABB241027410085C18E /* KDCircularProgress in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CABA241027410085C18E /* KDCircularProgress */; };
+		1FD8CABE241027620085C18E /* SWXMLHash in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CABD241027620085C18E /* SWXMLHash */; };
+		1FD8CAC1241028140085C18E /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAC0241028140085C18E /* RxSwift */; };
+		1FD8CAC3241028140085C18E /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAC2241028140085C18E /* RxCocoa */; };
+		1FD8CAC6241028C10085C18E /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAC5241028C10085C18E /* SnapKit */; };
 		1FDA2D3424062E2100523739 /* groovSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDA2D3324062E2100523739 /* groovSnapshot.swift */; };
 		1FDA2D3C24062E3000523739 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDA2D3B24062E3000523739 /* SnapshotHelper.swift */; };
 		31251DBFEDF78548A1A2A767 /* Pods_groov.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ABDD6A5EDEFF369926A285F5 /* Pods_groov.framework */; };
@@ -139,17 +139,17 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1FD8CAC1241028140085C18E /* BuildFile in Frameworks */,
-				1FD8CABE241027620085C18E /* BuildFile in Frameworks */,
-				1FD8CAC3241028140085C18E /* BuildFile in Frameworks */,
-				1FD8CAB2241026770085C18E /* BuildFile in Frameworks */,
-				1FD8CAB0241026770085C18E /* BuildFile in Frameworks */,
-				1FD8CAB8241027180085C18E /* BuildFile in Frameworks */,
-				1FD8CABB241027410085C18E /* BuildFile in Frameworks */,
+				1FD8CAC1241028140085C18E /* RxSwift in Frameworks */,
+				1FD8CABE241027620085C18E /* SWXMLHash in Frameworks */,
+				1FD8CAC3241028140085C18E /* RxCocoa in Frameworks */,
+				1FD8CAB2241026770085C18E /* RealmSwift in Frameworks */,
+				1FD8CAB0241026770085C18E /* Realm in Frameworks */,
+				1FD8CAB8241027180085C18E /* Moya in Frameworks */,
+				1FD8CABB241027410085C18E /* KDCircularProgress in Frameworks */,
 				C62533AA1D46F4A5006E43F8 /* MessageUI.framework in Frameworks */,
 				31251DBFEDF78548A1A2A767 /* Pods_groov.framework in Frameworks */,
-				1FD8CAB5241026B00085C18E /* BuildFile in Frameworks */,
-				1FD8CAC6241028C10085C18E /* BuildFile in Frameworks */,
+				1FD8CAB5241026B00085C18E /* Kingfisher in Frameworks */,
+				1FD8CAC6241028C10085C18E /* SnapKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -394,15 +394,15 @@
 			);
 			name = groov;
 			packageProductDependencies = (
-				1FD8CAAF241026770085C18E /* SwiftPackageProductDependency */,
-				1FD8CAB1241026770085C18E /* SwiftPackageProductDependency */,
-				1FD8CAB4241026B00085C18E /* SwiftPackageProductDependency */,
-				1FD8CAB7241027180085C18E /* SwiftPackageProductDependency */,
-				1FD8CABA241027410085C18E /* SwiftPackageProductDependency */,
-				1FD8CABD241027620085C18E /* SwiftPackageProductDependency */,
-				1FD8CAC0241028140085C18E /* SwiftPackageProductDependency */,
-				1FD8CAC2241028140085C18E /* SwiftPackageProductDependency */,
-				1FD8CAC5241028C10085C18E /* SwiftPackageProductDependency */,
+				1FD8CAAF241026770085C18E /* Realm */,
+				1FD8CAB1241026770085C18E /* RealmSwift */,
+				1FD8CAB4241026B00085C18E /* Kingfisher */,
+				1FD8CAB7241027180085C18E /* Moya */,
+				1FD8CABA241027410085C18E /* KDCircularProgress */,
+				1FD8CABD241027620085C18E /* SWXMLHash */,
+				1FD8CAC0241028140085C18E /* RxSwift */,
+				1FD8CAC2241028140085C18E /* RxCocoa */,
+				1FD8CAC5241028C10085C18E /* SnapKit */,
 			);
 			productName = groov;
 			productReference = C66ED4C41D2CA73E0055F441 /* GROOV..app */;
@@ -447,13 +447,13 @@
 			);
 			mainGroup = C66ED4BB1D2CA73E0055F441;
 			packageReferences = (
-				1FD8CAAE241026770085C18E /* RemoteSwiftPackageReference */,
-				1FD8CAB3241026AF0085C18E /* RemoteSwiftPackageReference */,
-				1FD8CAB6241027180085C18E /* RemoteSwiftPackageReference */,
-				1FD8CAB9241027410085C18E /* RemoteSwiftPackageReference */,
-				1FD8CABC241027620085C18E /* RemoteSwiftPackageReference */,
-				1FD8CABF241028140085C18E /* RemoteSwiftPackageReference */,
-				1FD8CAC4241028C10085C18E /* RemoteSwiftPackageReference */,
+				1FD8CAAE241026770085C18E /* XCRemoteSwiftPackageReference "realm-cocoa" */,
+				1FD8CAB3241026AF0085C18E /* XCRemoteSwiftPackageReference "Kingfisher" */,
+				1FD8CAB6241027180085C18E /* XCRemoteSwiftPackageReference "Moya" */,
+				1FD8CAB9241027410085C18E /* XCRemoteSwiftPackageReference "KDCircularProgress" */,
+				1FD8CABC241027620085C18E /* XCRemoteSwiftPackageReference "SWXMLHash" */,
+				1FD8CABF241028140085C18E /* XCRemoteSwiftPackageReference "RxSwift" */,
+				1FD8CAC4241028C10085C18E /* XCRemoteSwiftPackageReference "SnapKit" */,
 			);
 			productRefGroup = C66ED4C51D2CA73E0055F441 /* Products */;
 			projectDirPath = "";
@@ -858,6 +858,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -885,6 +886,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.feelg.groov";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};
@@ -921,7 +923,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		1FD8CAAE241026770085C18E /* RemoteSwiftPackageReference */ = {
+		1FD8CAAE241026770085C18E /* XCRemoteSwiftPackageReference "realm-cocoa" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/realm/realm-cocoa";
 			requirement = {
@@ -929,7 +931,7 @@
 				minimumVersion = 4.3.2;
 			};
 		};
-		1FD8CAB3241026AF0085C18E /* RemoteSwiftPackageReference */ = {
+		1FD8CAB3241026AF0085C18E /* XCRemoteSwiftPackageReference "Kingfisher" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/onevcat/Kingfisher";
 			requirement = {
@@ -937,7 +939,7 @@
 				minimumVersion = 5.13.2;
 			};
 		};
-		1FD8CAB6241027180085C18E /* RemoteSwiftPackageReference */ = {
+		1FD8CAB6241027180085C18E /* XCRemoteSwiftPackageReference "Moya" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Moya/Moya";
 			requirement = {
@@ -945,7 +947,7 @@
 				minimumVersion = 14.0.0;
 			};
 		};
-		1FD8CAB9241027410085C18E /* RemoteSwiftPackageReference */ = {
+		1FD8CAB9241027410085C18E /* XCRemoteSwiftPackageReference "KDCircularProgress" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kaandedeoglu/KDCircularProgress";
 			requirement = {
@@ -953,7 +955,7 @@
 				minimumVersion = 1.5.4;
 			};
 		};
-		1FD8CABC241027620085C18E /* RemoteSwiftPackageReference */ = {
+		1FD8CABC241027620085C18E /* XCRemoteSwiftPackageReference "SWXMLHash" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/drmohundro/SWXMLHash";
 			requirement = {
@@ -961,7 +963,7 @@
 				minimumVersion = 5.0.1;
 			};
 		};
-		1FD8CABF241028140085C18E /* RemoteSwiftPackageReference */ = {
+		1FD8CABF241028140085C18E /* XCRemoteSwiftPackageReference "RxSwift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ReactiveX/RxSwift";
 			requirement = {
@@ -969,7 +971,7 @@
 				minimumVersion = 5.1.0;
 			};
 		};
-		1FD8CAC4241028C10085C18E /* RemoteSwiftPackageReference */ = {
+		1FD8CAC4241028C10085C18E /* XCRemoteSwiftPackageReference "SnapKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SnapKit/SnapKit";
 			requirement = {
@@ -980,49 +982,49 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		1FD8CAAF241026770085C18E /* SwiftPackageProductDependency */ = {
+		1FD8CAAF241026770085C18E /* Realm */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 1FD8CAAE241026770085C18E /* RemoteSwiftPackageReference */;
+			package = 1FD8CAAE241026770085C18E /* XCRemoteSwiftPackageReference "realm-cocoa" */;
 			productName = Realm;
 		};
-		1FD8CAB1241026770085C18E /* SwiftPackageProductDependency */ = {
+		1FD8CAB1241026770085C18E /* RealmSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 1FD8CAAE241026770085C18E /* RemoteSwiftPackageReference */;
+			package = 1FD8CAAE241026770085C18E /* XCRemoteSwiftPackageReference "realm-cocoa" */;
 			productName = RealmSwift;
 		};
-		1FD8CAB4241026B00085C18E /* SwiftPackageProductDependency */ = {
+		1FD8CAB4241026B00085C18E /* Kingfisher */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 1FD8CAB3241026AF0085C18E /* RemoteSwiftPackageReference */;
+			package = 1FD8CAB3241026AF0085C18E /* XCRemoteSwiftPackageReference "Kingfisher" */;
 			productName = Kingfisher;
 		};
-		1FD8CAB7241027180085C18E /* SwiftPackageProductDependency */ = {
+		1FD8CAB7241027180085C18E /* Moya */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 1FD8CAB6241027180085C18E /* RemoteSwiftPackageReference */;
+			package = 1FD8CAB6241027180085C18E /* XCRemoteSwiftPackageReference "Moya" */;
 			productName = Moya;
 		};
-		1FD8CABA241027410085C18E /* SwiftPackageProductDependency */ = {
+		1FD8CABA241027410085C18E /* KDCircularProgress */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 1FD8CAB9241027410085C18E /* RemoteSwiftPackageReference */;
+			package = 1FD8CAB9241027410085C18E /* XCRemoteSwiftPackageReference "KDCircularProgress" */;
 			productName = KDCircularProgress;
 		};
-		1FD8CABD241027620085C18E /* SwiftPackageProductDependency */ = {
+		1FD8CABD241027620085C18E /* SWXMLHash */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 1FD8CABC241027620085C18E /* RemoteSwiftPackageReference */;
+			package = 1FD8CABC241027620085C18E /* XCRemoteSwiftPackageReference "SWXMLHash" */;
 			productName = SWXMLHash;
 		};
-		1FD8CAC0241028140085C18E /* SwiftPackageProductDependency */ = {
+		1FD8CAC0241028140085C18E /* RxSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 1FD8CABF241028140085C18E /* RemoteSwiftPackageReference */;
+			package = 1FD8CABF241028140085C18E /* XCRemoteSwiftPackageReference "RxSwift" */;
 			productName = RxSwift;
 		};
-		1FD8CAC2241028140085C18E /* SwiftPackageProductDependency */ = {
+		1FD8CAC2241028140085C18E /* RxCocoa */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 1FD8CABF241028140085C18E /* RemoteSwiftPackageReference */;
+			package = 1FD8CABF241028140085C18E /* XCRemoteSwiftPackageReference "RxSwift" */;
 			productName = RxCocoa;
 		};
-		1FD8CAC5241028C10085C18E /* SwiftPackageProductDependency */ = {
+		1FD8CAC5241028C10085C18E /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 1FD8CAC4241028C10085C18E /* RemoteSwiftPackageReference */;
+			package = 1FD8CAC4241028C10085C18E /* XCRemoteSwiftPackageReference "SnapKit" */;
 			productName = SnapKit;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/groov.xcodeproj/project.pbxproj
+++ b/groov.xcodeproj/project.pbxproj
@@ -34,15 +34,15 @@
 		1F9648AE240AE85E002D9FDA /* SettingsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9648AD240AE85E002D9FDA /* SettingsTableViewCell.swift */; };
 		1F9648B0240AEE30002D9FDA /* PlaylistFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9648AF240AEE30002D9FDA /* PlaylistFooterView.swift */; };
 		1F9648B6240B144F002D9FDA /* BlankView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9648B5240B144F002D9FDA /* BlankView.swift */; };
-		1FD8CAB0241026770085C18E /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAAF241026770085C18E /* Realm */; };
-		1FD8CAB2241026770085C18E /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAB1241026770085C18E /* RealmSwift */; };
-		1FD8CAB5241026B00085C18E /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAB4241026B00085C18E /* Kingfisher */; };
-		1FD8CAB8241027180085C18E /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAB7241027180085C18E /* Moya */; };
-		1FD8CABB241027410085C18E /* KDCircularProgress in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CABA241027410085C18E /* KDCircularProgress */; };
-		1FD8CABE241027620085C18E /* SWXMLHash in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CABD241027620085C18E /* SWXMLHash */; };
-		1FD8CAC1241028140085C18E /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAC0241028140085C18E /* RxSwift */; };
-		1FD8CAC3241028140085C18E /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAC2241028140085C18E /* RxCocoa */; };
-		1FD8CAC6241028C10085C18E /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAC5241028C10085C18E /* SnapKit */; };
+		1FD8CAB0241026770085C18E /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAAF241026770085C18E /* SwiftPackageProductDependency */; };
+		1FD8CAB2241026770085C18E /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAB1241026770085C18E /* SwiftPackageProductDependency */; };
+		1FD8CAB5241026B00085C18E /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAB4241026B00085C18E /* SwiftPackageProductDependency */; };
+		1FD8CAB8241027180085C18E /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAB7241027180085C18E /* SwiftPackageProductDependency */; };
+		1FD8CABB241027410085C18E /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CABA241027410085C18E /* SwiftPackageProductDependency */; };
+		1FD8CABE241027620085C18E /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CABD241027620085C18E /* SwiftPackageProductDependency */; };
+		1FD8CAC1241028140085C18E /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAC0241028140085C18E /* SwiftPackageProductDependency */; };
+		1FD8CAC3241028140085C18E /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAC2241028140085C18E /* SwiftPackageProductDependency */; };
+		1FD8CAC6241028C10085C18E /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAC5241028C10085C18E /* SwiftPackageProductDependency */; };
 		1FDA2D3424062E2100523739 /* groovSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDA2D3324062E2100523739 /* groovSnapshot.swift */; };
 		1FDA2D3C24062E3000523739 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDA2D3B24062E3000523739 /* SnapshotHelper.swift */; };
 		31251DBFEDF78548A1A2A767 /* Pods_groov.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ABDD6A5EDEFF369926A285F5 /* Pods_groov.framework */; };
@@ -139,17 +139,17 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1FD8CAC1241028140085C18E /* RxSwift in Frameworks */,
-				1FD8CABE241027620085C18E /* SWXMLHash in Frameworks */,
-				1FD8CAC3241028140085C18E /* RxCocoa in Frameworks */,
-				1FD8CAB2241026770085C18E /* RealmSwift in Frameworks */,
-				1FD8CAB0241026770085C18E /* Realm in Frameworks */,
-				1FD8CAB8241027180085C18E /* Moya in Frameworks */,
-				1FD8CABB241027410085C18E /* KDCircularProgress in Frameworks */,
+				1FD8CAC1241028140085C18E /* BuildFile in Frameworks */,
+				1FD8CABE241027620085C18E /* BuildFile in Frameworks */,
+				1FD8CAC3241028140085C18E /* BuildFile in Frameworks */,
+				1FD8CAB2241026770085C18E /* BuildFile in Frameworks */,
+				1FD8CAB0241026770085C18E /* BuildFile in Frameworks */,
+				1FD8CAB8241027180085C18E /* BuildFile in Frameworks */,
+				1FD8CABB241027410085C18E /* BuildFile in Frameworks */,
 				C62533AA1D46F4A5006E43F8 /* MessageUI.framework in Frameworks */,
 				31251DBFEDF78548A1A2A767 /* Pods_groov.framework in Frameworks */,
-				1FD8CAB5241026B00085C18E /* Kingfisher in Frameworks */,
-				1FD8CAC6241028C10085C18E /* SnapKit in Frameworks */,
+				1FD8CAB5241026B00085C18E /* BuildFile in Frameworks */,
+				1FD8CAC6241028C10085C18E /* BuildFile in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -394,15 +394,15 @@
 			);
 			name = groov;
 			packageProductDependencies = (
-				1FD8CAAF241026770085C18E /* Realm */,
-				1FD8CAB1241026770085C18E /* RealmSwift */,
-				1FD8CAB4241026B00085C18E /* Kingfisher */,
-				1FD8CAB7241027180085C18E /* Moya */,
-				1FD8CABA241027410085C18E /* KDCircularProgress */,
-				1FD8CABD241027620085C18E /* SWXMLHash */,
-				1FD8CAC0241028140085C18E /* RxSwift */,
-				1FD8CAC2241028140085C18E /* RxCocoa */,
-				1FD8CAC5241028C10085C18E /* SnapKit */,
+				1FD8CAAF241026770085C18E /* SwiftPackageProductDependency */,
+				1FD8CAB1241026770085C18E /* SwiftPackageProductDependency */,
+				1FD8CAB4241026B00085C18E /* SwiftPackageProductDependency */,
+				1FD8CAB7241027180085C18E /* SwiftPackageProductDependency */,
+				1FD8CABA241027410085C18E /* SwiftPackageProductDependency */,
+				1FD8CABD241027620085C18E /* SwiftPackageProductDependency */,
+				1FD8CAC0241028140085C18E /* SwiftPackageProductDependency */,
+				1FD8CAC2241028140085C18E /* SwiftPackageProductDependency */,
+				1FD8CAC5241028C10085C18E /* SwiftPackageProductDependency */,
 			);
 			productName = groov;
 			productReference = C66ED4C41D2CA73E0055F441 /* GROOV..app */;
@@ -447,13 +447,13 @@
 			);
 			mainGroup = C66ED4BB1D2CA73E0055F441;
 			packageReferences = (
-				1FD8CAAE241026770085C18E /* XCRemoteSwiftPackageReference "realm-cocoa" */,
-				1FD8CAB3241026AF0085C18E /* XCRemoteSwiftPackageReference "Kingfisher" */,
-				1FD8CAB6241027180085C18E /* XCRemoteSwiftPackageReference "Moya" */,
-				1FD8CAB9241027410085C18E /* XCRemoteSwiftPackageReference "KDCircularProgress" */,
-				1FD8CABC241027620085C18E /* XCRemoteSwiftPackageReference "SWXMLHash" */,
-				1FD8CABF241028140085C18E /* XCRemoteSwiftPackageReference "RxSwift" */,
-				1FD8CAC4241028C10085C18E /* XCRemoteSwiftPackageReference "SnapKit" */,
+				1FD8CAAE241026770085C18E /* RemoteSwiftPackageReference */,
+				1FD8CAB3241026AF0085C18E /* RemoteSwiftPackageReference */,
+				1FD8CAB6241027180085C18E /* RemoteSwiftPackageReference */,
+				1FD8CAB9241027410085C18E /* RemoteSwiftPackageReference */,
+				1FD8CABC241027620085C18E /* RemoteSwiftPackageReference */,
+				1FD8CABF241028140085C18E /* RemoteSwiftPackageReference */,
+				1FD8CAC4241028C10085C18E /* RemoteSwiftPackageReference */,
 			);
 			productRefGroup = C66ED4C51D2CA73E0055F441 /* Products */;
 			projectDirPath = "";
@@ -493,49 +493,12 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-groov/Pods-groov-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
-				"${BUILT_PRODUCTS_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework",
-				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac/GoogleToolboxForMac.framework",
-				"${BUILT_PRODUCTS_DIR}/GoogleUtilities/GoogleUtilities.framework",
-				"${BUILT_PRODUCTS_DIR}/KDCircularProgress/KDCircularProgress.framework",
-				"${BUILT_PRODUCTS_DIR}/Kingfisher/Kingfisher.framework",
-				"${BUILT_PRODUCTS_DIR}/Moya/Moya.framework",
-				"${BUILT_PRODUCTS_DIR}/PromisesObjC/FBLPromises.framework",
-				"${BUILT_PRODUCTS_DIR}/Protobuf/protobuf.framework",
-				"${BUILT_PRODUCTS_DIR}/Realm/Realm.framework",
-				"${BUILT_PRODUCTS_DIR}/RealmSwift/RealmSwift.framework",
-				"${BUILT_PRODUCTS_DIR}/RxCocoa/RxCocoa.framework",
-				"${BUILT_PRODUCTS_DIR}/RxRelay/RxRelay.framework",
-				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
-				"${BUILT_PRODUCTS_DIR}/SWXMLHash/SWXMLHash.framework",
-				"${BUILT_PRODUCTS_DIR}/SnapKit/SnapKit.framework",
-				"${BUILT_PRODUCTS_DIR}/SwiftMessages/SwiftMessages.framework",
-				"${BUILT_PRODUCTS_DIR}/YoutubeKit/YoutubeKit.framework",
-				"${BUILT_PRODUCTS_DIR}/nanopb/nanopb.framework",
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-groov/Pods-groov-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMSessionFetcher.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleToolboxForMac.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleUtilities.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/KDCircularProgress.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Kingfisher.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Moya.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBLPromises.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/protobuf.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Realm.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RealmSwift.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxRelay.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SWXMLHash.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SnapKit.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftMessages.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/YoutubeKit.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/nanopb.framework",
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-groov/Pods-groov-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -958,7 +921,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		1FD8CAAE241026770085C18E /* XCRemoteSwiftPackageReference "realm-cocoa" */ = {
+		1FD8CAAE241026770085C18E /* RemoteSwiftPackageReference */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/realm/realm-cocoa";
 			requirement = {
@@ -966,7 +929,7 @@
 				minimumVersion = 4.3.2;
 			};
 		};
-		1FD8CAB3241026AF0085C18E /* XCRemoteSwiftPackageReference "Kingfisher" */ = {
+		1FD8CAB3241026AF0085C18E /* RemoteSwiftPackageReference */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/onevcat/Kingfisher";
 			requirement = {
@@ -974,7 +937,7 @@
 				minimumVersion = 5.13.2;
 			};
 		};
-		1FD8CAB6241027180085C18E /* XCRemoteSwiftPackageReference "Moya" */ = {
+		1FD8CAB6241027180085C18E /* RemoteSwiftPackageReference */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Moya/Moya";
 			requirement = {
@@ -982,7 +945,7 @@
 				minimumVersion = 14.0.0;
 			};
 		};
-		1FD8CAB9241027410085C18E /* XCRemoteSwiftPackageReference "KDCircularProgress" */ = {
+		1FD8CAB9241027410085C18E /* RemoteSwiftPackageReference */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kaandedeoglu/KDCircularProgress";
 			requirement = {
@@ -990,7 +953,7 @@
 				minimumVersion = 1.5.4;
 			};
 		};
-		1FD8CABC241027620085C18E /* XCRemoteSwiftPackageReference "SWXMLHash" */ = {
+		1FD8CABC241027620085C18E /* RemoteSwiftPackageReference */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/drmohundro/SWXMLHash";
 			requirement = {
@@ -998,7 +961,7 @@
 				minimumVersion = 5.0.1;
 			};
 		};
-		1FD8CABF241028140085C18E /* XCRemoteSwiftPackageReference "RxSwift" */ = {
+		1FD8CABF241028140085C18E /* RemoteSwiftPackageReference */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ReactiveX/RxSwift";
 			requirement = {
@@ -1006,7 +969,7 @@
 				minimumVersion = 5.1.0;
 			};
 		};
-		1FD8CAC4241028C10085C18E /* XCRemoteSwiftPackageReference "SnapKit" */ = {
+		1FD8CAC4241028C10085C18E /* RemoteSwiftPackageReference */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SnapKit/SnapKit";
 			requirement = {
@@ -1017,49 +980,49 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		1FD8CAAF241026770085C18E /* Realm */ = {
+		1FD8CAAF241026770085C18E /* SwiftPackageProductDependency */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 1FD8CAAE241026770085C18E /* XCRemoteSwiftPackageReference "realm-cocoa" */;
+			package = 1FD8CAAE241026770085C18E /* RemoteSwiftPackageReference */;
 			productName = Realm;
 		};
-		1FD8CAB1241026770085C18E /* RealmSwift */ = {
+		1FD8CAB1241026770085C18E /* SwiftPackageProductDependency */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 1FD8CAAE241026770085C18E /* XCRemoteSwiftPackageReference "realm-cocoa" */;
+			package = 1FD8CAAE241026770085C18E /* RemoteSwiftPackageReference */;
 			productName = RealmSwift;
 		};
-		1FD8CAB4241026B00085C18E /* Kingfisher */ = {
+		1FD8CAB4241026B00085C18E /* SwiftPackageProductDependency */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 1FD8CAB3241026AF0085C18E /* XCRemoteSwiftPackageReference "Kingfisher" */;
+			package = 1FD8CAB3241026AF0085C18E /* RemoteSwiftPackageReference */;
 			productName = Kingfisher;
 		};
-		1FD8CAB7241027180085C18E /* Moya */ = {
+		1FD8CAB7241027180085C18E /* SwiftPackageProductDependency */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 1FD8CAB6241027180085C18E /* XCRemoteSwiftPackageReference "Moya" */;
+			package = 1FD8CAB6241027180085C18E /* RemoteSwiftPackageReference */;
 			productName = Moya;
 		};
-		1FD8CABA241027410085C18E /* KDCircularProgress */ = {
+		1FD8CABA241027410085C18E /* SwiftPackageProductDependency */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 1FD8CAB9241027410085C18E /* XCRemoteSwiftPackageReference "KDCircularProgress" */;
+			package = 1FD8CAB9241027410085C18E /* RemoteSwiftPackageReference */;
 			productName = KDCircularProgress;
 		};
-		1FD8CABD241027620085C18E /* SWXMLHash */ = {
+		1FD8CABD241027620085C18E /* SwiftPackageProductDependency */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 1FD8CABC241027620085C18E /* XCRemoteSwiftPackageReference "SWXMLHash" */;
+			package = 1FD8CABC241027620085C18E /* RemoteSwiftPackageReference */;
 			productName = SWXMLHash;
 		};
-		1FD8CAC0241028140085C18E /* RxSwift */ = {
+		1FD8CAC0241028140085C18E /* SwiftPackageProductDependency */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 1FD8CABF241028140085C18E /* XCRemoteSwiftPackageReference "RxSwift" */;
+			package = 1FD8CABF241028140085C18E /* RemoteSwiftPackageReference */;
 			productName = RxSwift;
 		};
-		1FD8CAC2241028140085C18E /* RxCocoa */ = {
+		1FD8CAC2241028140085C18E /* SwiftPackageProductDependency */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 1FD8CABF241028140085C18E /* XCRemoteSwiftPackageReference "RxSwift" */;
+			package = 1FD8CABF241028140085C18E /* RemoteSwiftPackageReference */;
 			productName = RxCocoa;
 		};
-		1FD8CAC5241028C10085C18E /* SnapKit */ = {
+		1FD8CAC5241028C10085C18E /* SwiftPackageProductDependency */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 1FD8CAC4241028C10085C18E /* XCRemoteSwiftPackageReference "SnapKit" */;
+			package = 1FD8CAC4241028C10085C18E /* RemoteSwiftPackageReference */;
 			productName = SnapKit;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/groov.xcodeproj/project.pbxproj
+++ b/groov.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -34,6 +34,15 @@
 		1F9648AE240AE85E002D9FDA /* SettingsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9648AD240AE85E002D9FDA /* SettingsTableViewCell.swift */; };
 		1F9648B0240AEE30002D9FDA /* PlaylistFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9648AF240AEE30002D9FDA /* PlaylistFooterView.swift */; };
 		1F9648B6240B144F002D9FDA /* BlankView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9648B5240B144F002D9FDA /* BlankView.swift */; };
+		1FD8CAB0241026770085C18E /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAAF241026770085C18E /* Realm */; };
+		1FD8CAB2241026770085C18E /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAB1241026770085C18E /* RealmSwift */; };
+		1FD8CAB5241026B00085C18E /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAB4241026B00085C18E /* Kingfisher */; };
+		1FD8CAB8241027180085C18E /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAB7241027180085C18E /* Moya */; };
+		1FD8CABB241027410085C18E /* KDCircularProgress in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CABA241027410085C18E /* KDCircularProgress */; };
+		1FD8CABE241027620085C18E /* SWXMLHash in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CABD241027620085C18E /* SWXMLHash */; };
+		1FD8CAC1241028140085C18E /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAC0241028140085C18E /* RxSwift */; };
+		1FD8CAC3241028140085C18E /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAC2241028140085C18E /* RxCocoa */; };
+		1FD8CAC6241028C10085C18E /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1FD8CAC5241028C10085C18E /* SnapKit */; };
 		1FDA2D3424062E2100523739 /* groovSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDA2D3324062E2100523739 /* groovSnapshot.swift */; };
 		1FDA2D3C24062E3000523739 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDA2D3B24062E3000523739 /* SnapshotHelper.swift */; };
 		31251DBFEDF78548A1A2A767 /* Pods_groov.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ABDD6A5EDEFF369926A285F5 /* Pods_groov.framework */; };
@@ -130,8 +139,17 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1FD8CAC1241028140085C18E /* RxSwift in Frameworks */,
+				1FD8CABE241027620085C18E /* SWXMLHash in Frameworks */,
+				1FD8CAC3241028140085C18E /* RxCocoa in Frameworks */,
+				1FD8CAB2241026770085C18E /* RealmSwift in Frameworks */,
+				1FD8CAB0241026770085C18E /* Realm in Frameworks */,
+				1FD8CAB8241027180085C18E /* Moya in Frameworks */,
+				1FD8CABB241027410085C18E /* KDCircularProgress in Frameworks */,
 				C62533AA1D46F4A5006E43F8 /* MessageUI.framework in Frameworks */,
 				31251DBFEDF78548A1A2A767 /* Pods_groov.framework in Frameworks */,
+				1FD8CAB5241026B00085C18E /* Kingfisher in Frameworks */,
+				1FD8CAC6241028C10085C18E /* SnapKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -375,6 +393,17 @@
 			dependencies = (
 			);
 			name = groov;
+			packageProductDependencies = (
+				1FD8CAAF241026770085C18E /* Realm */,
+				1FD8CAB1241026770085C18E /* RealmSwift */,
+				1FD8CAB4241026B00085C18E /* Kingfisher */,
+				1FD8CAB7241027180085C18E /* Moya */,
+				1FD8CABA241027410085C18E /* KDCircularProgress */,
+				1FD8CABD241027620085C18E /* SWXMLHash */,
+				1FD8CAC0241028140085C18E /* RxSwift */,
+				1FD8CAC2241028140085C18E /* RxCocoa */,
+				1FD8CAC5241028C10085C18E /* SnapKit */,
+			);
 			productName = groov;
 			productReference = C66ED4C41D2CA73E0055F441 /* GROOV..app */;
 			productType = "com.apple.product-type.application";
@@ -417,6 +446,15 @@
 				"zh-Hant",
 			);
 			mainGroup = C66ED4BB1D2CA73E0055F441;
+			packageReferences = (
+				1FD8CAAE241026770085C18E /* XCRemoteSwiftPackageReference "realm-cocoa" */,
+				1FD8CAB3241026AF0085C18E /* XCRemoteSwiftPackageReference "Kingfisher" */,
+				1FD8CAB6241027180085C18E /* XCRemoteSwiftPackageReference "Moya" */,
+				1FD8CAB9241027410085C18E /* XCRemoteSwiftPackageReference "KDCircularProgress" */,
+				1FD8CABC241027620085C18E /* XCRemoteSwiftPackageReference "SWXMLHash" */,
+				1FD8CABF241028140085C18E /* XCRemoteSwiftPackageReference "RxSwift" */,
+				1FD8CAC4241028C10085C18E /* XCRemoteSwiftPackageReference "SnapKit" */,
+			);
 			productRefGroup = C66ED4C51D2CA73E0055F441 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -675,7 +713,11 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = groovSnapshot/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = app.overtheocean.groovSnapshot;
@@ -703,7 +745,11 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = groovSnapshot/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = app.overtheocean.groovSnapshot;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -817,7 +863,8 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -835,7 +882,10 @@
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = groov/Resources/info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited) -D DEBUG";
 				PODS_PODFILE_DIR_PATH = "$(inherited)";
@@ -860,7 +910,10 @@
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = groov/Resources/info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PODS_PODFILE_DIR_PATH = "$(inherited)";
@@ -903,6 +956,113 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		1FD8CAAE241026770085C18E /* XCRemoteSwiftPackageReference "realm-cocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/realm/realm-cocoa";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.3.2;
+			};
+		};
+		1FD8CAB3241026AF0085C18E /* XCRemoteSwiftPackageReference "Kingfisher" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/onevcat/Kingfisher";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.13.2;
+			};
+		};
+		1FD8CAB6241027180085C18E /* XCRemoteSwiftPackageReference "Moya" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Moya/Moya";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 14.0.0;
+			};
+		};
+		1FD8CAB9241027410085C18E /* XCRemoteSwiftPackageReference "KDCircularProgress" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kaandedeoglu/KDCircularProgress";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.5.4;
+			};
+		};
+		1FD8CABC241027620085C18E /* XCRemoteSwiftPackageReference "SWXMLHash" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/drmohundro/SWXMLHash";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.1;
+			};
+		};
+		1FD8CABF241028140085C18E /* XCRemoteSwiftPackageReference "RxSwift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ReactiveX/RxSwift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.1.0;
+			};
+		};
+		1FD8CAC4241028C10085C18E /* XCRemoteSwiftPackageReference "SnapKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SnapKit/SnapKit";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		1FD8CAAF241026770085C18E /* Realm */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1FD8CAAE241026770085C18E /* XCRemoteSwiftPackageReference "realm-cocoa" */;
+			productName = Realm;
+		};
+		1FD8CAB1241026770085C18E /* RealmSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1FD8CAAE241026770085C18E /* XCRemoteSwiftPackageReference "realm-cocoa" */;
+			productName = RealmSwift;
+		};
+		1FD8CAB4241026B00085C18E /* Kingfisher */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1FD8CAB3241026AF0085C18E /* XCRemoteSwiftPackageReference "Kingfisher" */;
+			productName = Kingfisher;
+		};
+		1FD8CAB7241027180085C18E /* Moya */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1FD8CAB6241027180085C18E /* XCRemoteSwiftPackageReference "Moya" */;
+			productName = Moya;
+		};
+		1FD8CABA241027410085C18E /* KDCircularProgress */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1FD8CAB9241027410085C18E /* XCRemoteSwiftPackageReference "KDCircularProgress" */;
+			productName = KDCircularProgress;
+		};
+		1FD8CABD241027620085C18E /* SWXMLHash */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1FD8CABC241027620085C18E /* XCRemoteSwiftPackageReference "SWXMLHash" */;
+			productName = SWXMLHash;
+		};
+		1FD8CAC0241028140085C18E /* RxSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1FD8CABF241028140085C18E /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxSwift;
+		};
+		1FD8CAC2241028140085C18E /* RxCocoa */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1FD8CABF241028140085C18E /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxCocoa;
+		};
+		1FD8CAC5241028C10085C18E /* SnapKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1FD8CAC4241028C10085C18E /* XCRemoteSwiftPackageReference "SnapKit" */;
+			productName = SnapKit;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = C66ED4BC1D2CA73E0055F441 /* Project object */;
 }

--- a/podfile
+++ b/podfile
@@ -3,20 +3,12 @@ platform :ios, '12.0'
 target 'groov' do
   use_frameworks!
 
-  pod 'RealmSwift'
-  pod 'Kingfisher', 	          '~> 5.0'
-  pod 'Moya',                   '~> 14.0'
-  pod 'KDCircularProgress',     '~> 1.5.4'
-  pod 'SWXMLHash',	            '~> 5.0.0'
   pod 'Firebase/Core'
   pod 'Firebase/Performance'
   pod 'SwiftMessages',          '~> 7.0.0'
   pod 'Fabric',                 '~> 1.7.2'
   pod 'Crashlytics',            '~> 3.9.3'
   pod 'YoutubeKit', :git => 'https://github.com/mildwhale/YoutubeKit.git', :tag => '0.4.2'
-  pod 'RxSwift', '~> 5'
-  pod 'RxCocoa', '~> 5'
-  pod 'SnapKit', '~> 5.0.0'
 
 end
 


### PR DESCRIPTION
CocoaPods에서 SPM으로 옮길 수 있는 것들은 모두 옮겼습니다.

아직 남은 것들은 다음과 같습니다.

```
pod 'Firebase/Core'
pod 'Firebase/Performance'
pod 'SwiftMessages'
pod 'Fabric'
pod 'Crashlytics'
pod 'YoutubeKit'
```
얘네들은 각자 다른 이유로 SPM으로 안넘어가고 있는 것 같습니다.
일단 당장 적용 가능한 것들만 적용해두었습니다.
